### PR TITLE
Escape the output of lsb-release.

### DIFF
--- a/update-motd.d/10-banner
+++ b/update-motd.d/10-banner
@@ -38,4 +38,4 @@ fi
 echo -e "  "$DISTRIB_DESCRIPTION "(kernel "$(uname -r)")\n"
 
 # Update the information for next time
-printf "DISTRIB_DESCRIPTION=%s" "$(lsb_release -s -d)" > /etc/update-motd.d/lsb-release &
+printf "DISTRIB_DESCRIPTION=\"%s\"" "$(lsb_release -s -d)" > /etc/update-motd.d/lsb-release &


### PR DESCRIPTION
There can be problematic characters in the output of lsb_release -s -d
e.g.: Debian GNU/Linux 9.8 (stretch)

which later leads to the error:

/etc/update-motd.d/lsb-release: line 1: syntax error near unexpected
token `('

Escaping the output fixed it.