### PR TITLE
Refactor sysinfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Last login: Fri Apr 22 09:23:01 2016 from laptop.example.org
 You need to install some packages:
 
 ```
-apt-get install figlet lsb-release python-utmp bc
+apt-get install figlet lsb-release bc
 ```
 
 Optionnally, you can install `needrestart` which is used to show a message if your server need a reboot (main reason (and the only one I know): you have upgraded your kernel).

--- a/README.md
+++ b/README.md
@@ -52,11 +52,6 @@ If you don't install `needrestart`, it will work, but you won't be warned about 
 
 You can optionnally install `debian-goodies` which provides `checkrestart`, which will be used to warn you about services that need to be restarted. Relying on `needrestart` for that is slow (±7 seconds) while `checkrestart` do it faster (less than one second).
 
-**NB:** if you use Debian 11 Bullseye, install `python3-utmp` instead of `python-utmp` and change `python` to `python3` in `update-motd.d/20-system-info` and `update-motd.d/sysinfo.py`:
-
-```
-sed -e "s/python/python3/" -i update-motd.d/20-system-info update-motd.d/sysinfo.py
-```
 
 ## Installation
 

--- a/update-motd.d/20-system-info
+++ b/update-motd.d/20-system-info
@@ -10,7 +10,7 @@ threshold="${cores:-1}.0"
 echo
 
 if [ $(echo "`cut -f1 -d ' ' /proc/loadavg` < $threshold" | bc) -eq 1 ]; then
-    python /etc/update-motd.d/sysinfo.py
+    python3 /etc/update-motd.d/sysinfo.py
 else
     echo " System information disabled due to load higher than $threshold"
 fi

--- a/update-motd.d/sysinfo.py
+++ b/update-motd.d/sysinfo.py
@@ -112,49 +112,53 @@ def get_filesystems():
     return filesystems
 
 
-loadav = float(open("/proc/loadavg").read().split()[1])
-processes = len(glob.glob("/proc/[0-9]*"))
-ip_addr = dev_addr(default_dev())
-filesystems = get_filesystems()
-users = get_users()
-meminfo = proc_meminfo()
-memperc = "%d%%" % (
-    100 - 100.0 * meminfo["MemAvailable:"] / (meminfo["MemTotal:"] or 1)
-)
-swapperc = "%d%%" % (100 - 100.0 * meminfo["SwapFree:"] / (meminfo["SwapTotal:"] or 1))
+def main():
 
-if meminfo["SwapTotal:"] == 0:
-    swapperc = "---"
+    loadav = float(open("/proc/loadavg").read().split()[1])
+    processes = len(glob.glob("/proc/[0-9]*"))
+    meminfo = proc_meminfo()
+    filesystems = get_filesystems()
+    ip_addr = dev_addr(default_dev())
+    memperc = "%d%%" % (
+        100 - 100.0 * meminfo["MemAvailable:"] / (meminfo["MemTotal:"] or 1)
+    )
+    swapperc = "%d%%" % (
+        100 - 100.0 * meminfo["SwapFree:"] / (meminfo["SwapTotal:"] or 1)
+    )
+    users = get_users()
 
-print(
-    """
+    if meminfo["SwapTotal:"] == 0:
+        swapperc = "---"
+
+    print(
+        """
 System information as of %s on %s
 """
-    % (time.asctime(), ip_addr)
-)
-print(
-    "  System load:  %-5.2f                Processes:           %d"
-    % (loadav, processes)
-)
-print("  Memory usage: %-4s                 Users logged in:     %d" % (memperc, users))
-print("  Swap usage:   %s" % (swapperc))
-
-print("System load:  %-5.2f                Processes:    %d" % (loadav, processes))
-print("Memory usage: %-4s                 Swap usage:   %s" % (memperc, swapperc))
-
-print(
-    """
-  Mount points          Disk usage        Inodes usage"""
-)
-
-for f in filesystems:
-    print(" %-21s %-4s of %-9s %s" % (f["target"], f["use%"], f["size"], f["inodes%"]))
-
-if users != "":
-    print(
-        f"""
-   Logged in users: {users}
-"""
+        % (time.asctime(), ip_addr)
     )
 
-sys.exit(0)
+    print("System load:  %-5.2f                Processes:    %d" % (loadav, processes))
+    print("Memory usage: %-4s                 Swap usage:   %s" % (memperc, swapperc))
+
+    print(
+        """
+  Mount points          Disk usage        Inodes usage"""
+    )
+
+    for f in filesystems:
+        print(
+            " %-21s %-4s of %-9s %s" % (f["target"], f["use%"], f["size"], f["inodes%"])
+        )
+
+    if users != "":
+        print(
+            f"""
+  Logged in users: {users}
+"""
+        )
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/update-motd.d/sysinfo.py
+++ b/update-motd.d/sysinfo.py
@@ -1,12 +1,12 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
-# landscape-sysinfo-mini.py -- a trivial re-implementation of the 
+# landscape-sysinfo-mini.py -- a trivial re-implementation of the
 # sysinfo printout shown on debian at boot time. No twisted, no reactor, just /proc & utmp
 #
 # (C) 2014 jw@owncloud.com
 #
 # inspired by ubuntu 14.10 /etc/update-motd.d/50-landscape-sysinfo
-# Requires: python-utmp 
+# Requires: python-utmp
 # for counting users.
 #
 # 2014-09-07 V1.0 jw, ad hoc writeup, feature-complete. Probably buggy?
@@ -16,81 +16,109 @@
 # Modified by Luc Didry in 2016
 # Get the original version at https://github.com/jnweiger/landscape-sysinfo-mini
 
-import sys,os,time,posix,glob,utmp
+import glob
+import os
+import posix
+import sys
+import time
+
+import utmp
 from UTMPCONST import *
 
-_version_ = '1.2'
+_version_ = "1.2"
+
 
 def utmp_count():
-  u = utmp.UtmpRecord()
-  users = 0
-  for i in u:
-    if i.ut_type == utmp.USER_PROCESS: users += 1
-  return users
+    u = utmp.UtmpRecord()
+    users = 0
+    for i in u:
+        if i.ut_type == utmp.USER_PROCESS:
+            users += 1
+    return users
+
 
 def proc_meminfo():
-  items = {}
-  for l in open('/proc/meminfo').readlines():
-    a = l.split()
-    items[a[0]] = int(a[1])
-  # print items['MemTotal:'], items['MemFree:'], items['SwapTotal:'], items['SwapFree:']
-  return items
+    items = {}
+    for l in open("/proc/meminfo").readlines():
+        a = l.split()
+        items[a[0]] = int(a[1])
+    # print items['MemTotal:'], items['MemFree:'], items['SwapTotal:'], items['SwapFree:']
+    return items
+
 
 def proc_mount():
-  items = {}
-  for m in open('/proc/mounts').readlines():
-    a = m.split()
-    if a[0].find('/dev/') == 0:
-      statfs = os.statvfs(a[1])
-      perc = 100-100.*statfs.f_bavail/statfs.f_blocks if statfs.f_blocks != 0 else 100
-      gb = statfs.f_bsize*statfs.f_blocks/1024./1024/1024
-      items[a[1]] = "%.1f%% of %.2fGB" % (perc, gb)
-  return items
+    items = {}
+    for m in open("/proc/mounts").readlines():
+        a = m.split()
+        if a[0].find("/dev/") == 0:
+            statfs = os.statvfs(a[1])
+            perc = (
+                100 - 100.0 * statfs.f_bavail / statfs.f_blocks
+                if statfs.f_blocks != 0
+                else 100
+            )
+            gb = statfs.f_bsize * statfs.f_blocks / 1024.0 / 1024 / 1024
+            items[a[1]] = "%.1f%% of %.2fGB" % (perc, gb)
+    return items
+
 
 def inode_proc_mount():
-  items = {}
-  for m in open('/proc/mounts').readlines():
-    a = m.split()
-    if a[0].find('/dev/') == 0:
-      statfs = os.statvfs(a[1])
-      perc = 100-100.*statfs.f_ffree/statfs.f_files if statfs.f_files != 0 else 100
-      iTotal = statfs.f_files
-      items[a[1]] = "%.1f%% of %.2d" % (perc, iTotal)
-  return items
+    items = {}
+    for m in open("/proc/mounts").readlines():
+        a = m.split()
+        if a[0].find("/dev/") == 0:
+            statfs = os.statvfs(a[1])
+            perc = (
+                100 - 100.0 * statfs.f_ffree / statfs.f_files
+                if statfs.f_files != 0
+                else 100
+            )
+            iTotal = statfs.f_files
+            items[a[1]] = "%.1f%% of %.2d" % (perc, iTotal)
+    return items
+
 
 loadav = float(open("/proc/loadavg").read().split()[1])
-processes = len(glob.glob('/proc/[0-9]*'))
+processes = len(glob.glob("/proc/[0-9]*"))
 statfs = proc_mount()
 iStatfs = inode_proc_mount()
 users = utmp_count()
 meminfo = proc_meminfo()
-memperc = "%d%%" % (100-100.*meminfo['MemAvailable:']/(meminfo['MemTotal:'] or 1))
-swapperc = "%d%%" % (100-100.*meminfo['SwapFree:']/(meminfo['SwapTotal:'] or 1))
+memperc = "%d%%" % (
+    100 - 100.0 * meminfo["MemAvailable:"] / (meminfo["MemTotal:"] or 1)
+)
+swapperc = "%d%%" % (100 - 100.0 * meminfo["SwapFree:"] / (meminfo["SwapTotal:"] or 1))
 
-if meminfo['SwapTotal:'] == 0: swapperc = '---'
+if meminfo["SwapTotal:"] == 0:
+    swapperc = "---"
 
 print("  System information as of %s\n" % time.asctime())
-print("  System load:  %-5.2f                Processes:           %d" % (loadav, processes))
+print(
+    "  System load:  %-5.2f                Processes:           %d"
+    % (loadav, processes)
+)
 print("  Memory usage: %-4s                 Users logged in:     %d" % (memperc, users))
 print("  Swap usage:   %s" % (swapperc))
 
 print("  Disk Usage:")
 for k in sorted(statfs.keys()):
-  print("    Usage of %-24s: %-20s" % (k, statfs[k]))
+    print("    Usage of %-24s: %-20s" % (k, statfs[k]))
 
 print("  Inode Usage:")
 for l in sorted(iStatfs.keys()):
-  print("    Usage of %-24s: %-20s" % (l, iStatfs[l]))
+    print("    Usage of %-24s: %-20s" % (l, iStatfs[l]))
 
 if users > 0:
     a = utmp.UtmpRecord()
 
     print("\n  Logged in users:")
 
-    for b in a: # example of using an iterator
+    for b in a:  # example of using an iterator
         if b.ut_type == USER_PROCESS:
-            print("  \033[1;31m%-10s\033[m from %-25s at %-20s" % \
-            (b.ut_user, b.ut_host, time.ctime(b.ut_tv[0])))
+            print(
+                "  \033[1;31m%-10s\033[m from %-25s at %-20s"
+                % (b.ut_user, b.ut_host, time.ctime(b.ut_tv[0]))
+            )
     a.endutent()
 
 sys.exit(0)

--- a/update-motd.d/sysinfo.py
+++ b/update-motd.d/sysinfo.py
@@ -3,18 +3,18 @@
 # landscape-sysinfo-mini.py -- a trivial re-implementation of the
 # sysinfo printout shown on debian at boot time. No twisted, no reactor, just /proc & utmp
 #
-# (C) 2014 jw@owncloud.com
+# (C) 2014 jw@owncloud.com https://github.com/jnweiger/landscape-sysinfo-mini
+# (C) 2016 Luc Didry https://github.com/ldidry/dynamic-motd/blob/master/update-motd.d/sysinfo.py
+# (C) 2024 seven-beep@entreparentheses.xyz
 #
 # inspired by ubuntu 14.10 /etc/update-motd.d/50-landscape-sysinfo
-# Requires: python-utmp
-# for counting users.
 #
-# 2014-09-07 V1.0 jw, ad hoc writeup, feature-complete. Probably buggy?
-# 2014-10-08 V1.1 jw, survive without swap
-# 2014-10-13 V1.2 jw, survive without network
-
-# Modified by Luc Didry in 2016
-# Get the original version at https://github.com/jnweiger/landscape-sysinfo-mini
+# 2014-09-07 V1.0 -- jw, ad hoc writeup, feature-complete. Probably buggy?
+# 2014-10-08 V1.1 -- jw, survive without swap
+# 2014-10-13 V1.2 -- jw, survive without network
+# 2016            -- Luc Didry
+# 2024-09-04 V1.3 -- 7b, remove dependance on utmp, rework disk usage, add error
+# handling, change spacing, restore ip address.
 
 import glob
 import os


### PR DESCRIPTION
Hello,

I am not sure all will interest you but I have passed a few hours to refactor the sysinfo python script for my own usage :

- use python3
- dropped utmp for a more trivial output with the command "who"
- use the findmnt command to filter the mounts and produce a more compact output
- added error handling on theses statfs calls
- restored the ip of the main interface
- use a main function
