### PR TITLE
Refactor sysinfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Example:
 
   Debian GNU/Linux 12 (bookworm) (kernel 6.1.0-7-amd64)
 
-System information as of Wed Jan 22 16:02:47 2025 on x.x.x.x
+System information as of Wed Jan 22 16:02:47 2025
 
 System load:  0.07                 Processes:    245
 Memory usage: 26%                  Swap usage:   1%

--- a/README.md
+++ b/README.md
@@ -14,23 +14,27 @@ Example:
 
   Debian GNU/Linux 12 (bookworm) (kernel 6.1.0-7-amd64)
 
-System information as of Wed Jan 22 15:35:40 2025 on x.x.x.x
+System information as of Wed Jan 22 16:02:47 2025 on x.x.x.x
 
-System load:  0.07                 Processes:    244
+System load:  0.07                 Processes:    245
 Memory usage: 26%                  Swap usage:   1%
 
-  Mount points          Disk usage        Inodes usage
- /boot                 12%  of 977.3M    0.5% of 65808
- /boot/efi             0%   of 250.1M    Not available
- /                     13%  of 19.6G     5.0% of 1310720
- /home                 1%   of 7.8G      1.3% of 524288
- /var                  43%  of 19.6G     16.6% of 1310720
- /var/log              2%   of 7.8G      0.0% of 524288
- /var/log/audit        0%   of 7.8G      0.0% of 524288
- /var/tmp              0%   of 4.8G      0.0% of 327680
+  Mount points                        Disk usage        Inodes usage
+ /                                   13%  of 19.6G     5.0% of 1310720
+ /boot                               12%  of 977.3M    0.5% of 65808
+ /var                                43%  of 19.6G     16.6% of 1310720
+ /home                               1%   of 7.8G      1.3% of 524288
+ /var/log                            2%   of 7.8G      0.0% of 524288
+ /var/tmp                            0%   of 4.8G      0.0% of 327680
+ /boot/efi                           0%   of 250.1M    Not available
+ /var/log/audit                      0%   of 7.8G      0.0% of 524288
+ /srv/borg                           0%   of 1.3T      0.0% of 85901312
+ /srv/nextcloud                      13%  of 3T        0.0% of 201326592
+ /mnt/disquette                      78%  of 1.2T      0.1% of 82378752
 
- 5 logged in users:
-  admin       from x.x.x.x                 at Tue Jan 21 22:43:37 2025
+  2 logged in users:
+  user       from x.x.x.x                   at Tue Jan 21 22:43:37 2025
+  user       from x.x.x.x                   at Tue Jan 21 22:43:37 2025
 
 No mail.
 Last login: Mon Apr  3 07:28:01 2023 from laptop.example.org

--- a/README.md
+++ b/README.md
@@ -14,23 +14,23 @@ Example:
 
   Debian GNU/Linux 12 (bookworm) (kernel 6.1.0-7-amd64)
 
-System information as of Fri Sep  6 10:26:52 2024 on 192.168.1.20
+System information as of Wed Jan 22 15:35:40 2025 on x.x.x.x
 
-System load:  0.01                 Processes:    211
-Memory usage: 24.40%               Swap usage:   0.02%
+System load:  0.07                 Processes:    244
+Memory usage: 26%                  Swap usage:   1%
 
   Mount points          Disk usage        Inodes usage
- /                     18%  of 14G       8.7% of 938400
- /boot                 8%   of 1.8G      0.0% of 999936
- /boot/efi             1%   of 974.1M    Not available
- /opt                  3%   of 4.6G      0.0% of 312624
- /var                  13%  of 4.6G      1.4% of 312624
- /var/log              2%   of 4.6G      0.0% of 312624
- /var/log/audit        0%   of 4.6G      0.0% of 312624
- /var/tmp              0%   of 4.6G      0.0% of 312624
+ /boot                 12%  of 977.3M    0.5% of 65808
+ /boot/efi             0%   of 250.1M    Not available
+ /                     13%  of 19.6G     5.0% of 1310720
+ /home                 1%   of 7.8G      1.3% of 524288
+ /var                  43%  of 19.6G     16.6% of 1310720
+ /var/log              2%   of 7.8G      0.0% of 524288
+ /var/log/audit        0%   of 7.8G      0.0% of 524288
+ /var/tmp              0%   of 4.8G      0.0% of 327680
 
-       Logged in users: admin
-
+ 5 logged in users:
+  admin       from x.x.x.x                 at Tue Jan 21 22:43:37 2025
 
 No mail.
 Last login: Mon Apr  3 07:28:01 2023 from laptop.example.org
@@ -55,7 +55,7 @@ sudo apt install ./dynamic-motd_*.deb
 You need to install some packages:
 
 ```
-apt-get install figlet lsb-release bc
+apt-get install figlet lsb-release bc python3-utmp
 ```
 
 Optionally, you can install `needrestart` which is used to show a message if your server need a reboot (main reason (and the only one I know): you have upgraded your kernel).

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ sudo apt install ./dynamic-motd_*.deb
 You need to install some packages:
 
 ```
-apt-get install figlet lsb-release python3-utmp bc
+apt-get install figlet lsb-release bc
 ```
 
 Optionally, you can install `needrestart` which is used to show a message if your server need a reboot (main reason (and the only one I know): you have upgraded your kernel).

--- a/README.md
+++ b/README.md
@@ -14,23 +14,23 @@ Example:
 
   Debian GNU/Linux 12 (bookworm) (kernel 6.1.0-7-amd64)
 
+System information as of Fri Sep  6 10:26:52 2024 on 192.168.1.20
 
-  System information as of Thu Apr 13 08:43:28 2023
+System load:  0.01                 Processes:    211
+Memory usage: 24.40%               Swap usage:   0.02%
 
-  System load:  2.84                 Processes:           338
-  Memory usage: 81.69%               Users logged in:     1
-  Swap usage:   21.34%
-  Disk Usage:
-    Usage of /                       : 37.0% of 19.18GB
-    Usage of /boot                   : 36.6% of 0.11GB
-    Usage of /home                   : 11.1% of 501.60GB
-  Inode Usage:
-    Usage of /                       : 12.7% of 1286144
-    Usage of /boot                   : 1.1% of 31232
-    Usage of /home                   : 0.1% of 33406976
+  Mount points          Disk usage        Inodes usage
+ /                     18%  of 14G       8.7% of 938400
+ /boot                 8%   of 1.8G      0.0% of 999936
+ /boot/efi             1%   of 974.1M    Not available
+ /opt                  3%   of 4.6G      0.0% of 312624
+ /var                  13%  of 4.6G      1.4% of 312624
+ /var/log              2%   of 4.6G      0.0% of 312624
+ /var/log/audit        0%   of 4.6G      0.0% of 312624
+ /var/tmp              0%   of 4.6G      0.0% of 312624
 
-  Logged in users:
-  user       from laptop.example.org        at Mon Apr  3 09:28:01 2023
+       Logged in users: admin
+
 
 No mail.
 Last login: Mon Apr  3 07:28:01 2023 from laptop.example.org

--- a/update-motd.d/30-need-upgrade
+++ b/update-motd.d/30-need-upgrade
@@ -8,7 +8,7 @@ n=$(apt list --upgradable 2>/dev/null | wc -l)
 if [ "$n" -gt 0 ]; then
     printf "%b  You have %s packages waiting for upgrades.%b\n\n" "$LIGHT_RED" "$n" "$NONE"
 fi
-n=$(apt --just-print autoremove | grep -c Remv)
+n=$(apt --just-print autoremove 2>/dev/null | grep -c Remv)
 if [ "$n" -gt 0 ]; then
     printf "%b  You have %s packages that were automatically installed and are not needed anymore.%b\n\n" "$YELLOW" "$n" "$NONE"
 fi

--- a/update-motd.d/30-need-upgrade
+++ b/update-motd.d/30-need-upgrade
@@ -4,11 +4,11 @@ CURRENT_DIR=$(dirname "$0")
 . "$CURRENT_DIR/quiet"
 . "$CURRENT_DIR/colors"
 
-n=$(apt list --upgradable 2>/dev/null | wc -l)
+n=$(apt --quiet --quiet list --upgradable 2>/dev/null | wc -l)
 if [ "$n" -gt 0 ]; then
     printf "%b  You have %s packages waiting for upgrades.%b\n\n" "$LIGHT_RED" "$n" "$NONE"
 fi
-n=$(apt --just-print autoremove 2>/dev/null | grep -c Remv)
+n=$(apt --quiet --quiet --just-print autoremove 2>/dev/null | grep -c Remv)
 if [ "$n" -gt 0 ]; then
     printf "%b  You have %s packages that were automatically installed and are not needed anymore.%b\n\n" "$YELLOW" "$n" "$NONE"
 fi

--- a/update-motd.d/40-need-reboot
+++ b/update-motd.d/40-need-reboot
@@ -5,5 +5,5 @@ CURRENT_DIR=$(dirname "$0")
 . "$CURRENT_DIR/colors"
 
 if [ -e /var/run/reboot-required ]; then
-    printf "%b  Pending kernel upgrade! %bYou should consider rebooting your machine.\n\n" "$LIGHT_RED" "$NONE"
+    printf "%b  Reboot required by specific packages updates! %bYou should consider restarting your machine.\n\n" "$LIGHT_RED" "$NONE"
 fi

--- a/update-motd.d/sysinfo.py
+++ b/update-motd.d/sysinfo.py
@@ -79,7 +79,6 @@ def get_filesystems():
                 "--noheading",
                 "--real",
                 "--uniq",
-                "--fstab",
                 "--json",
                 "--types",
                 "notmpfs,noswap,nodevtmpfs",
@@ -139,12 +138,12 @@ def main():
 
     print(
         """
-  Mount points          Disk usage        Inodes usage"""
+  Mount points                         Disk usage       Inodes usage"""
     )
 
     for f in filesystems:
         print(
-            " %-21s %-4s of %-9s %s" % (f["target"], f["use%"], f["size"], f["inodes%"])
+            " %-35s %-4s of %-9s %s" % (f["target"], f["use%"], f["size"], f["inodes%"])
         )
 
     if logged_users > 0:

--- a/update-motd.d/sysinfo.py
+++ b/update-motd.d/sysinfo.py
@@ -122,31 +122,28 @@ def main():
     with open("/proc/loadavg", encoding="ASCII") as avg_line:
         loadav = float(avg_line.read().split()[1])
     processes = len(glob.glob("/proc/[0-9]*"))
-
-    ip_addr = get_ip_addr()
-    filesystems = get_filesystems()
-    users = get_users()
     meminfo = proc_meminfo()
-    memperc = (
-        f"{100 - 100. * meminfo['MemAvailable:'] / (meminfo['MemTotal:'] or 1):.2f}%"
+    filesystems = get_filesystems()
     ip_addr = dev_addr(default_dev())
+    memperc = "%d%%" % (
+        100 - 100.0 * meminfo["MemAvailable:"] / (meminfo["MemTotal:"] or 1)
     )
-    SWAPPERC = (
-        f"{100 - 100. * meminfo['SwapFree:'] / (meminfo['SwapTotal:'] or 1):.2f}%"
+    swapperc = "%d%%" % (
+        100 - 100.0 * meminfo["SwapFree:"] / (meminfo["SwapTotal:"] or 1)
     )
+    users = get_users()
 
     if meminfo["SwapTotal:"] == 0:
-        SWAPPERC = "---"
+        swapperc = "---"
 
     print(
-        """
-System information as of %s on %s
-    """
+        """System information as of %s on %s
+"""
         % (time.asctime(), ip_addr)
     )
 
     print("System load:  %-5.2f                Processes:    %d" % (loadav, processes))
-    print("Memory usage: %-7s              Swap usage:   %s" % (memperc, SWAPPERC))
+    print("Memory usage: %-4s                 Swap usage:   %s" % (memperc, swapperc))
 
     print(
         """
@@ -161,8 +158,7 @@ System information as of %s on %s
     if users != "":
         print(
             f"""
-       Logged in users: {users}
-    """
+  Logged in users: {users}"""
         )
 
     sys.exit(0)

--- a/update-motd.d/sysinfo.py
+++ b/update-motd.d/sysinfo.py
@@ -3,21 +3,19 @@
 landscape-sysinfo-mini.py -- a trivial re-implementation of the
 sysinfo printout shown on debian at boot time. No twisted, no reactor, just /proc & utmp
 
-(C) 2014 jw@owncloud.com
-https://github.com/jnweiger/landscape-sysinfo-mini
+(C) 2014 jw@owncloud.com https://github.com/jnweiger/landscape-sysinfo-mini
+(C) 2016, 2023 Luc Didry https://github.com/ldidry/dynamic-motd/blob/master/update-motd.d/sysinfo.py
+(C) 2024 seven-beep@entreparentheses.xyz
 
 inspired by ubuntu 14.10 /etc/update-motd.d/50-landscape-sysinfo
 
-2014-09-07 V1.0 jw, ad hoc writeup, feature-complete. Probably buggy?
-2014-10-08 V1.1 jw, survive without swap
-2014-10-13 V1.2 jw, survive without network
-
-Modified by Luc Didry in 2016 and 2023
-https://github.com/ldidry/dynamic-motd
-
-Modified by seven-beep@entreparentheses.xyz in 2024.
+2014-09-07 V1.0 -- jw, ad hoc writeup, feature-complete. Probably buggy?
+2014-10-08 V1.1 -- jw, survive without swap
+2014-10-13 V1.2 -- jw, survive without network
+2016, 2023      -- Luc Didry
+2024-09-04 V1.3 -- 7b, remove dependance on utmp, rework disk usage, add error
+handling, change spacing, restore ip address.
 """
-
 
 import glob
 import json

--- a/update-motd.d/sysinfo.py
+++ b/update-motd.d/sysinfo.py
@@ -14,8 +14,8 @@ inspired by ubuntu 14.10 /etc/update-motd.d/50-landscape-sysinfo
 2014-10-13 V1.2 -- jw, survive without network
 2016, 2023      -- Luc Didry
 2024-09-04 V1.3 -- 7b, remove dependance on utmp, rework disk usage, add error
+handling, change spacing...
 2025-09-25 V1.4 -- 7b, timeout on filesystem scan
-handling, change spacing, restore ip address.
 """
 
 import functools
@@ -102,7 +102,7 @@ def get_filesystems():
                 "--uniq",
                 "--json",
                 "--types",
-                "notmpfs,noswap,nodevtmpfs",
+                "notmpfs,noswap,nodevtmpfs,noxenfs",
                 "--df",
             ]
         )

--- a/update-motd.d/sysinfo.py
+++ b/update-motd.d/sysinfo.py
@@ -36,28 +36,6 @@ def utmp_count():
     return l_users
 
 
-def dev_addr(device):
-    """find the local ip address on the given device"""
-    if device is None:
-        return None
-    for l in os.popen("ip route list dev " + device):
-        seen = ""
-        for a in l.split():
-            if seen == "src":
-                return a
-            seen = a
-    return None
-
-
-def default_dev():
-    """find the device where our default route is"""
-    for l in open("/proc/net/route").readlines():
-        a = l.split()
-        if a[1] == "00000000":
-            return a[0]
-    return None
-
-
 def proc_meminfo():
     """Get memory usage informations"""
     items = {}
@@ -116,7 +94,6 @@ def main():
     processes = len(glob.glob("/proc/[0-9]*"))
     meminfo = proc_meminfo()
     filesystems = get_filesystems()
-    ip_addr = dev_addr(default_dev())
     memperc = "%d%%" % (
         100 - 100.0 * meminfo["MemAvailable:"] / (meminfo["MemTotal:"] or 1)
     )
@@ -127,12 +104,7 @@ def main():
     if meminfo["SwapTotal:"] == 0:
         swapperc = "---"
 
-    print(
-        """System information as of %s on %s
-"""
-        % (time.asctime(), ip_addr)
-    )
-
+    print("System information as of %s\n" % time.asctime())
     print("System load:  %-5.2f                Processes:    %d" % (loadav, processes))
     print("Memory usage: %-4s                 Swap usage:   %s" % (memperc, swapperc))
 

--- a/update-motd.d/sysinfo.py
+++ b/update-motd.d/sysinfo.py
@@ -90,7 +90,7 @@ def get_filesystems():
                 "--fstab",
                 "--json",
                 "--types",
-                "notmpfs,noswap",
+                "notmpfs,noswap,nodevtmpfs",
                 "--df",
             ]
         )

--- a/update-motd.d/sysinfo.py
+++ b/update-motd.d/sysinfo.py
@@ -4,17 +4,18 @@ landscape-sysinfo-mini.py -- a trivial re-implementation of the
 sysinfo printout shown on debian at boot time. No twisted, no reactor, just /proc & utmp
 
 (C) 2014 jw@owncloud.com
+https://github.com/jnweiger/landscape-sysinfo-mini
 
 inspired by ubuntu 14.10 /etc/update-motd.d/50-landscape-sysinfo
-Requires: python3-utmp
-for counting users.
 
 2014-09-07 V1.0 jw, ad hoc writeup, feature-complete. Probably buggy?
 2014-10-08 V1.1 jw, survive without swap
 2014-10-13 V1.2 jw, survive without network
 
 Modified by Luc Didry in 2016 and 2023
-Get the original version at https://github.com/jnweiger/landscape-sysinfo-mini
+https://github.com/ldidry/dynamic-motd
+
+Modified by seven-beep@entreparentheses.xyz in 2024.
 """
 
 
@@ -27,7 +28,7 @@ import time
 
 
 def dev_addr(device):
-    """find the local ip address on the given device"""
+    """Find the local ip address on the given device"""
     if device is None:
         return None
     for l in os.popen("ip route list dev " + device):
@@ -40,7 +41,7 @@ def dev_addr(device):
 
 
 def default_dev():
-    """find the device where our default route is"""
+    """Find the device where our default route is"""
     for l in open("/proc/net/route").readlines():
         a = l.split()
         if a[1] == "00000000":
@@ -49,6 +50,7 @@ def default_dev():
 
 
 def get_users():
+    """Get the users connected on this machine."""
     # Run the who command and capture its output
     who_output_list = subprocess.check_output(["who"]).decode("utf-8").split("\n")
     # Create a set to store unique usernames
@@ -78,6 +80,7 @@ def proc_meminfo():
 
 
 def get_filesystems():
+    """Get the real filesystem information for all entries in /etc/fstab."""
     # Only using fstab values to filter the mess that can be containerisation or bind mounts.
     filesystems = json.loads(
         subprocess.check_output(

--- a/update-motd.d/sysinfo.py
+++ b/update-motd.d/sysinfo.py
@@ -27,26 +27,14 @@ import sys
 import time
 
 
-def dev_addr(device):
+def get_ip_addr():
     """Find the local ip address on the given device"""
-    if device is None:
-        return None
-    for l in os.popen("ip route list dev " + device):
-        seen = ""
-        for a in l.split():
-            if seen == "src":
-                return a
-            seen = a
-    return None
+    ip_output_list = (
+        subprocess.check_output(["hostname", "-I"]).decode("utf-8").split(" ")
+    )
 
-
-def default_dev():
-    """Find the device where our default route is"""
-    for l in open("/proc/net/route").readlines():
-        a = l.split()
-        if a[1] == "00000000":
-            return a[0]
-    return None
+    if bool(ip_output_list):
+        return ip_output_list[0]
 
 
 def get_users():
@@ -125,7 +113,7 @@ def main():
         loadav = float(avg_line.read().split()[1])
     processes = len(glob.glob("/proc/[0-9]*"))
 
-    ip_addr = dev_addr(default_dev())
+    ip_addr = get_ip_addr()
     filesystems = get_filesystems()
     users = get_users()
     meminfo = proc_meminfo()

--- a/update-motd.d/sysinfo.py
+++ b/update-motd.d/sysinfo.py
@@ -25,6 +25,28 @@ import sys
 import time
 
 
+def dev_addr(device):
+    """find the local ip address on the given device"""
+    if device is None:
+        return None
+    for l in os.popen("ip route list dev " + device):
+        seen = ""
+        for a in l.split():
+            if seen == "src":
+                return a
+            seen = a
+    return None
+
+
+def default_dev():
+    """find the device where our default route is"""
+    for l in open("/proc/net/route").readlines():
+        a = l.split()
+        if a[1] == "00000000":
+            return a[0]
+    return None
+
+
 def get_users():
     # Run the who command and capture its output
     who_output_list = subprocess.check_output(["who"]).decode("utf-8").split("\n")
@@ -80,9 +102,14 @@ def inode_proc_mount():
             items[array[1]] = f"{perc:5.1f}% of {i_total}"
     return items
 
+<<<<<<< HEAD
 with open("/proc/loadavg", encoding="ASCII") as avg_line:
     loadav = float(avg_line.read().split()[1])
 processes = len(glob.glob('/proc/[0-9]*'))
+=======
+
+ip_addr = dev_addr(default_dev())
+>>>>>>> 5fa57c4 (Restore ip address)
 statfs = proc_mount()
 i_statfs = inode_proc_mount()
 users = get_users()
@@ -93,10 +120,19 @@ SWAPPERC = f"{100 - 100. * meminfo['SwapFree:'] / (meminfo['SwapTotal:'] or 1):.
 if meminfo['SwapTotal:'] == 0:
     SWAPPERC = '---'
 
+<<<<<<< HEAD
 print(f"  System information as of {time.asctime()}\n")
 print(f"  System load:  {loadav: <5.2f}                Processes:           {processes}")
 print(f"  Memory usage: {memperc: <4}               Users logged in:     {USERS}")
 print(f"  Swap usage:   {SWAPPERC}")
+=======
+print(
+    """
+System information as of %s on %s
+"""
+    % (time.asctime(), ip_addr)
+)
+>>>>>>> 5fa57c4 (Restore ip address)
 
 print("  Disk Usage:")
 for k in sorted(statfs.keys()):

--- a/update-motd.d/sysinfo.py
+++ b/update-motd.d/sysinfo.py
@@ -116,43 +116,55 @@ def get_filesystems():
     return filesystems
 
 
-with open("/proc/loadavg", encoding="ASCII") as avg_line:
-    loadav = float(avg_line.read().split()[1])
-processes = len(glob.glob("/proc/[0-9]*"))
+def main():
 
-ip_addr = dev_addr(default_dev())
-filesystems = get_filesystems()
-users = get_users()
-meminfo = proc_meminfo()
-memperc = f"{100 - 100. * meminfo['MemAvailable:'] / (meminfo['MemTotal:'] or 1):.2f}%"
-SWAPPERC = f"{100 - 100. * meminfo['SwapFree:'] / (meminfo['SwapTotal:'] or 1):.2f}%"
+    with open("/proc/loadavg", encoding="ASCII") as avg_line:
+        loadav = float(avg_line.read().split()[1])
+    processes = len(glob.glob("/proc/[0-9]*"))
 
-if meminfo["SwapTotal:"] == 0:
-    SWAPPERC = "---"
-
-print(
-    """
-System information as of %s on %s
-"""
-    % (time.asctime(), ip_addr)
-)
-
-print("System load:  %-5.2f                Processes:    %d" % (loadav, processes))
-print("Memory usage: %-4s                 Swap usage:   %s" % (memperc, SWAPPERC))
-
-print(
-    """
-  Mount points          Disk usage        Inodes usage"""
-)
-
-for f in filesystems:
-    print(" %-21s %-4s of %-9s %s" % (f["target"], f["use%"], f["size"], f["inodes%"]))
-
-if users != "":
-    print(
-        f"""
-   Logged in users: {users}
-"""
+    ip_addr = dev_addr(default_dev())
+    filesystems = get_filesystems()
+    users = get_users()
+    meminfo = proc_meminfo()
+    memperc = (
+        f"{100 - 100. * meminfo['MemAvailable:'] / (meminfo['MemTotal:'] or 1):.2f}%"
+    )
+    SWAPPERC = (
+        f"{100 - 100. * meminfo['SwapFree:'] / (meminfo['SwapTotal:'] or 1):.2f}%"
     )
 
-sys.exit(0)
+    if meminfo["SwapTotal:"] == 0:
+        SWAPPERC = "---"
+
+    print(
+        """
+    System information as of %s on %s
+    """
+        % (time.asctime(), ip_addr)
+    )
+
+    print("System load:  %-5.2f                Processes:    %d" % (loadav, processes))
+    print("Memory usage: %-4s                 Swap usage:   %s" % (memperc, SWAPPERC))
+
+    print(
+        """
+      Mount points          Disk usage        Inodes usage"""
+    )
+
+    for f in filesystems:
+        print(
+            " %-21s %-4s of %-9s %s" % (f["target"], f["use%"], f["size"], f["inodes%"])
+        )
+
+    if users != "":
+        print(
+            f"""
+       Logged in users: {users}
+    """
+        )
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/update-motd.d/sysinfo.py
+++ b/update-motd.d/sysinfo.py
@@ -129,7 +129,7 @@ def main():
 
     print(
         """
-    System information as of %s on %s
+System information as of %s on %s
     """
         % (time.asctime(), ip_addr)
     )
@@ -139,7 +139,7 @@ def main():
 
     print(
         """
-   Mount points          Disk usage        Inodes usage"""
+  Mount points          Disk usage        Inodes usage"""
     )
 
     for f in filesystems:

--- a/update-motd.d/sysinfo.py
+++ b/update-motd.d/sysinfo.py
@@ -147,11 +147,11 @@ def main():
     )
 
     print("System load:  %-5.2f                Processes:    %d" % (loadav, processes))
-    print("Memory usage: %-4s                 Swap usage:   %s" % (memperc, SWAPPERC))
+    print("Memory usage: %-7s              Swap usage:   %s" % (memperc, SWAPPERC))
 
     print(
         """
-      Mount points          Disk usage        Inodes usage"""
+   Mount points          Disk usage        Inodes usage"""
     )
 
     for f in filesystems:


### PR DESCRIPTION
> Sorry, but could you rebase your modifications on the main branch?

Here we go :)

original message: 

I am not sure all will interest you but I have passed a few hours to refactor the sysinfo python script for my own usage :

   - use python3
   - dropped utmp for a more trivial output with the command "who"
   -  use the findmnt command to filter the mounts and produce a more compact output
   - added error handling on theses statfs calls
   - restored the ip of the main interface
   - use a main function

